### PR TITLE
cmap-check-default-overwrite

### DIFF
--- a/backend/config/docs/api_config.json
+++ b/backend/config/docs/api_config.json
@@ -26,6 +26,8 @@
             "performance" : 0,
             "admin" : 1  
         },
+        "colors-default-cmaps" : ["Blues","Set7","Spectral","Greys"],
+        "colors-overwrite-by-defaults" : 1,
         "db-feature-annotations" : ["Entry","Protein names","Gene names","Gene names  (primary )","Organism"],
         "db-summary-params" : [
                 "Gene names",

--- a/backend/helper/Submission.py
+++ b/backend/helper/Submission.py
@@ -247,10 +247,17 @@ class Submission(object):
             return params
         else:
             return {}
+
     def add(self,sampleSubmission) -> bool:
         ""
         if "dataID" not in sampleSubmission:
             return False
+        if "groupingCmap" not in sampleSubmission and "groupings" in sampleSubmission:
+            cmapDefaults = self.data.getAPIParam("default-cmaps")
+            if isinstance(cmapDefaults,list) and len(cmapDefaults) >= len(sampleSubmission["groupings"]):
+                sampleSubmission["groupingCmap"] = OrderedDict([(groupingName,cmapDefaults[n]) for n,groupingName in enumerate(sampleSubmission["groupings"])])
+            else:
+                return False
         dataID = sampleSubmission["dataID"]
         #check folder
         if dataID in self._getListOfSubmissions():

--- a/backend/resources/dataset/Examples.py
+++ b/backend/resources/dataset/Examples.py
@@ -60,5 +60,8 @@ class DatasetParamsExample(Resource):
                 "title" : expHeader,
                 "details" : "Fill details here..."
             })
-        return {"success" : False, "msg" : "not all params found.","tokenIsValid":True}
+        ##add MitoCube internal groupings
+        paramsExample["groupings"] = {"groupingName1" : {"groupName-1" : ["sampleName01","sampleName02"], "groupName-2" : ["sampleNames03","sampleName04"]}}
+        paramsExample["groupingNames"] = ["groupingName1"]
+        paramsExample["groupingCmap"] = {"groupingName1" : "<string>: Blues color palette"}
         return {"success" : True, "paramsFile" : paramsExample, "tokenIsValid" : True}

--- a/backend/resources/submission/Submissions.py
+++ b/backend/resources/submission/Submissions.py
@@ -8,6 +8,7 @@ import json
 from datetime import date
 from ..utils.html import *
 from ..misc import isAdminValid, adminTokenInValidResponse
+from ...helper.Misc import getCurrentDate
 
 def handleDetailInputs(submissionDetail):
     """"""
@@ -172,6 +173,8 @@ class DataSubmissionDetails(Resource):
                             sampleSubmission[submissionHeader] = dateString
                         else:
                             sampleSubmission[submissionHeader] = submission["details"][submissionHeader]
+                    elif submissionHeader == "Creation Date":
+                        sampleSubmission[submissionHeader] = getCurrentDate()
                     else: 
                         return {"success":False,"msg":"The API expected more information. Could not find: {}.".format(submissionHeader)}
                 #manage experimental info 

--- a/src/components/submission/MCGroupingTable.js
+++ b/src/components/submission/MCGroupingTable.js
@@ -254,7 +254,7 @@ export function MCGroupingTable(props) {
                     const runNames = _.uniq(dataArray.map(v => v[_.indexOf(columnNames, "Run")]))
                     
                  
-                    const dataTable = dataArray.map((rowData,rowIdx) => Object.fromEntries(rowData.map((v, i) => {
+                    let dataTable = dataArray.map((rowData,rowIdx) => Object.fromEntries(rowData.map((v, i) => {
                         if (allowCustomRunNames && columnNames[i] === "Run") {
                             
                             return ([columnNames[i], runNames[rowIdx]])
@@ -262,8 +262,7 @@ export function MCGroupingTable(props) {
                         return ([columnNames[i], v])
                     })))
                    
-                   
-                    console.log(dataTable)
+                    dataTable = _.filter(dataTable, rowData => Object.keys(rowData).length > 0) // remove lines that are empty
                     const numberOfGroupings = columnNames.length - 2 // Run and Replicate must be the in the file
                     handleTemplateInput(columnNames,dataTable,replicates.length,numSamples,numberOfGroupings)
 


### PR DESCRIPTION
The problem when using submission-based generated params.json files was that the cmap (color mappings groupingName -> colorMap (e.g. Blues, Spectral etc)) was missing and the backend was not able to pick a color. Therefore
* cmaps are now added for groupings when a submission is added. The default cmaps used can be defined in the config. We maybe can discuss if the user should do that, but I guess that goes crazy. 
* In addition: One can define in the config that the cmaps defined in the datasets, can be overwritten by the defaults hence allowing for uniform color coding throughout the datasets.

The following params were added to the config. 

        "colors-default-cmaps" : ["Blues","Set7","Spectral","Greys"],
        "colors-overwrite-by-defaults" : 1,

with the respective defaults. When overwrite-by-defaults equals 1, then the param is just overwritten when loaded into the DataseCollection, the file itself is not modified. 

In addition, the Example for a dataset params file was updated to include the cmaps mapping.